### PR TITLE
Modify the default timestamp bubble schema to use the proper variable for minutes

### DIFF
--- a/Settings.jsx
+++ b/Settings.jsx
@@ -32,7 +32,7 @@ module.exports = class Settings extends React.PureComponent {
         </TextInput>
         <TextInput
           note="Schematic that message timestamp bubbles (when you hover over a timestamp) will follow."
-          defaultValue={settings.getSetting("timestampBubbleSchematic", "%W, %N %D, %Y %h:%0M %AM")}
+          defaultValue={settings.getSetting("timestampBubbleSchematic", "%W, %N %D, %Y %h:%0m %AM")}
           onChange={(val) =>
             settings.updateSetting("timestampBubbleSchematic", val)
           }


### PR DESCRIPTION
This PR makes the following change: Replaces the `%0M` variable in the default timestamp bubble schematic with `%0m` so that it properly displays the minute the message was sent. Should fix the issue that was reported in the Powercord server by `รקย๔
#2020` for new users of the plugin.