### PR TITLE
Added settings to enable/disable overrides

### DIFF
--- a/Settings.jsx
+++ b/Settings.jsx
@@ -40,16 +40,16 @@ module.exports = class Settings extends React.PureComponent {
         </TextInput>
         <SwitchItem
           note="Whether the chat timestamp should be overwritten."
-          value={settings.getSetting("enableChatTimestamp", false)}
+          value={settings.getSetting("enableChatTimestamp", true)}
           onChange={p=>{
-            settings.toggleSetting('enableChatTimestamp', false)
+            settings.toggleSetting('enableChatTimestamp', true)
           }}
         >Overwrite Chat Timestamp</SwitchItem>
         <SwitchItem
           note="Whether the hover timestamp should be overwritten."
-          value={settings.getSetting("enableHoverTimestamp", false)}
+          value={settings.getSetting("enableHoverTimestamp", true)}
           onChange={p=>{
-            settings.toggleSetting('enableHoverTimestamp', false)
+            settings.toggleSetting('enableHoverTimestamp', true)
           }}
         >Overwrite Hover Timestamp</SwitchItem>
         {/* <TextInput

--- a/Settings.jsx
+++ b/Settings.jsx
@@ -38,6 +38,20 @@ module.exports = class Settings extends React.PureComponent {
         >
           Timestamp Bubble Schematic
         </TextInput>
+        <SwitchItem
+          note="Whether the chat timestamp should be overwritten."
+          value={settings.getSetting("enableChatTimestamp", false)}
+          onChange={p=>{
+            settings.toggleSetting('enableChatTimestamp', false)
+          }}
+        >Overwrite Chat Timestamp</SwitchItem>
+        <SwitchItem
+          note="Whether the hover timestamp should be overwritten."
+          value={settings.getSetting("enableHoverTimestamp", false)}
+          onChange={p=>{
+            settings.toggleSetting('enableHoverTimestamp', false)
+          }}
+        >Overwrite Hover Timestamp</SwitchItem>
         {/* <TextInput
           note="Color of the timestamp. Any CSS color is valid."
           defaultValue={settings.getSetting("timestampColor", "var(--text-muted)")}

--- a/index.js
+++ b/index.js
@@ -73,9 +73,9 @@ module.exports = class CustomTimestamps extends Plugin {
       (args, res) => {
         try {
           const timestampParsed = this.parseTimestamp(args[0].timestamp)
-          if (settings.get("enableHoverTimestamp", false)) res.props.children.props.text = this.parseTimestamp(args[0].timestamp, true);
+          if (settings.get("enableHoverTimestamp", true)) res.props.children.props.text = this.parseTimestamp(args[0].timestamp, true);
           const { children } = res.props.children.props;
-          if (settings.get("enableChatTimestamp", false)) {
+          if (settings.get("enableChatTimestamp", true)) {
             res.props.children.props.children = e => {
               const r = children(e);
               if (r.props.children?.props?.className?.indexOf?.("edited") === 0) return r;

--- a/index.js
+++ b/index.js
@@ -73,15 +73,17 @@ module.exports = class CustomTimestamps extends Plugin {
       (args, res) => {
         try {
           const timestampParsed = this.parseTimestamp(args[0].timestamp)
-          res.props.children.props.text = this.parseTimestamp(args[0].timestamp, true);
+          if (settings.get("enableHoverTimestamp", false)) res.props.children.props.text = this.parseTimestamp(args[0].timestamp, true);
           const { children } = res.props.children.props;
-          res.props.children.props.children = e => {
-            const r = children(e);
-            if (r.props.children?.props?.className?.indexOf?.("edited") === 0) return r;
-            r.props["aria-label"] = timestampParsed;
-            r.props.children = timestampParsed;
-            //r.props.style = { color: this.settings.get("timestampColor", "var(--text-muted)") };
-            return r;
+          if (settings.get("enableChatTimestamp", false)) {
+            res.props.children.props.children = e => {
+              const r = children(e);
+              if (r.props.children?.props?.className?.indexOf?.("edited") === 0) return r;
+              r.props["aria-label"] = timestampParsed;
+              r.props.children = timestampParsed;
+              //r.props.style = { color: this.settings.get("timestampColor", "var(--text-muted)") };
+              return r;
+            }
           }
           return res;
         } catch (err) {


### PR DESCRIPTION
This adds settings to enable or disable chat and hover timestamp overrides.

I added this locally as I don't like the chat timestamp being overridden.
I would prefer the default value to be true. But I'm not a 100% sure on how to do that (or if it's even possible).